### PR TITLE
move drawSlider call

### DIFF
--- a/module-03/lab-03/lab-03-data/index.html
+++ b/module-03/lab-03/lab-03-data/index.html
@@ -141,6 +141,7 @@
             box-shadow: 0 0 15px rgba(0, 0, 0, 0.2);
             border-radius: 5px;
             text-align: center;
+            width: 160px;
         }
         
         .info h3 {
@@ -229,6 +230,7 @@
             drawLegend();          
             drawMap(counties);
             updateMap();
+            drawSlider();
         }
 
 
@@ -276,7 +278,6 @@
 
             // call other functions that update the map
             updateLegend(breaks);
-            drawSlider();
             estVizGoods();
         }
 


### PR DESCRIPTION
- because the UI action on the slider called the updateMap() function, which also called the code to create the slider repeatedly, was choking up on the slider: moved the drawSlider function call to only be called once.
